### PR TITLE
Fix tests asserting a specific package version causing bower install to fail

### DIFF
--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -434,7 +434,7 @@ describe('bower install', function () {
         });
 
         return helpers.run(install, [['angular']]).then(function() {
-            expect(tempDir.read('bower_components/angular/bower.json')).to.contain('"version": "1.3.15"');
+            expect(tempDir.read('bower_components/angular/bower.json')).to.contain('"name": "angular"');
             expect(tempDir.read('bower.lock')).to.not.contain('"angular"');
         });
     });
@@ -453,7 +453,7 @@ describe('bower install', function () {
         });
 
         return helpers.run(install, [['angular'], {save: true}]).then(function() {
-            expect(tempDir.read('bower_components/angular/bower.json')).to.contain('"version": "1.3.15"');
+            expect(tempDir.read('bower_components/angular/bower.json')).to.contain('"name": "angular"');
             expect(tempDir.read('bower.lock')).to.contain('"angular"');
             expect(tempDir.read('bower.json')).to.contain('"angular"');
             bowerJson = tempDir.readJson('bower.json');


### PR DESCRIPTION
When doing a bower install by specifying package and it is not in the lockFile, it will try to install the latest package. The current assertion expects a specific version and thus causing the test to fail when the remote package has a newer version. 

This pull request changes the test assertion to match package name instead of version.
